### PR TITLE
Add a watchdog script that runs separately and warns if the job fails

### DIFF
--- a/crash_rate_aggregates/watchdog.sh
+++ b/crash_rate_aggregates/watchdog.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# watchdog timer for crash aggregator - if the aggregator job doesn't successfully complete within 10 hours, send out warning emails to telemetry-alerts@mozilla.com
+# successful completion is marked by the existance of the file `crash_aggregates/JOB_SUCCESS`
+# intended to be used with run_crash_aggregator.ipynb
+
+SCRIPT_DIR=$(dirname "$(readlink -f -- "$0")") # get the directory this script is in
+
+subject='[TIMEOUT] Crash rate aggregates job'
+body='
+Crash rate aggregates job failed to complete within 10 hours. Check logs at https://analysis.telemetry.mozilla.org/cluster/schedule for details.
+
+This is an automatically generated message from the crash aggregates watchdog. The source code is available at https://github.com/mozilla/moz-crash-rate-aggregates.
+'
+
+sleep 36000 # 10 hours * 60 minutes/hours * 60 seconds/minutes = 36000 seconds
+if [ ! -f "$SCRIPT_DIR/JOB_SUCCESS" ]; then
+  aws ses send-email --from telemetry-alerts@mozilla.com --to telemetry-alerts@mozilla.com --text "$body" --subject "$subject"
+fi

--- a/run_crash_aggregator.ipynb
+++ b/run_crash_aggregator.ipynb
@@ -12,6 +12,7 @@
     "import os\n",
     "os.system(\"git clone https://github.com/mozilla/moz-crash-rate-aggregates.git\")\n",
     "os.chdir(\"moz-crash-rate-aggregates/crash_rate_aggregates\")\n",
+    "os.system(\"watchdog.sh &\") # start the watchdog in the background\n",
     "import crash_aggregator"
    ]
   },
@@ -36,6 +37,17 @@
    "outputs": [],
    "source": [
     "crash_aggregator.run_job(sc, sqlContext, (yesterday_utc, yesterday_utc))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "os.system(\"touch JOB_SUCCESS\")"
    ]
   }
  ],

--- a/run_crash_aggregator.ipynb
+++ b/run_crash_aggregator.ipynb
@@ -12,7 +12,7 @@
     "import os\n",
     "os.system(\"git clone https://github.com/mozilla/moz-crash-rate-aggregates.git\")\n",
     "os.chdir(\"moz-crash-rate-aggregates/crash_rate_aggregates\")\n",
-    "os.system(\"watchdog.sh &\") # start the watchdog in the background\n",
+    "os.system(\"nohup watchdog.sh &\") # start the watchdog in the background\n",
     "import crash_aggregator"
    ]
   },


### PR DESCRIPTION
The watchdog script warns users if the analysis job fails.

It's a separate script because sometimes Spark errors (bugs?) can take down the entire IPython kernel with no exceptions. Also, it's less likely to get killed if there's an OOM error.

It runs on the same instance as the job runs on, is started by the bootstrap notebook, and then runs totally independently until it times out.

Alerts are sent to telemetry-alerts@mozilla.com, which people can subscribe to if they want these failure warnings.
