### PR TITLE
Add counters to the aggregator and clean up code a bit

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,6 @@ Vagrant.configure("2") do |config|
     dev.ssh.insert_key = false
     dev.vm.box = "ubuntu/trusty64"
     dev.vm.network :forwarded_port, host: 4040, guest: 4040 # forward the SparkUI port for testing
-    dev.vm.network :forwarded_port, host: 5432, guest: 5432 # forward the Postgresql port for testing
     dev.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible/dev.yml"
     end

--- a/crash_rate_aggregates/crash_aggregator.py
+++ b/crash_rate_aggregates/crash_aggregator.py
@@ -24,6 +24,7 @@ COMPARABLE_DIMENSIONS = [
     ("environment", "addons", "activeExperiment", "id"),
     ("environment", "addons", "activeExperiment", "branch"),
     ("environment", "settings", "e10sEnabled"),
+    ("environment", "settings", "e10sCohort"),
 ]
 
 # names of the comparable dimensions above, used as dimension names in the database
@@ -39,6 +40,7 @@ DIMENSION_NAMES = [
     "experiment_id",
     "experiment_branch",
     "e10s_enabled",
+    "e10s_cohort",
 ]
 
 assert len(COMPARABLE_DIMENSIONS) == len(DIMENSION_NAMES), \

--- a/crash_rate_aggregates/crash_aggregator.py
+++ b/crash_rate_aggregates/crash_aggregator.py
@@ -290,14 +290,14 @@ def run_job(spark_context, sql_context, submission_date_range, use_test_data=Fal
         )
         df.write.parquet(s3_result_url)
 
-        print("SUCCESSFULLY UPLOADED CRASH AGGREGATES FOR {} TO S3".format(current_date))
+        print("SUCCESSFULLY UPLOADED CRASH AGGREGATES FOR {} TO S3:".format(current_date))
+        print("{} main pings processed, {} main pings ignored".format(main_processed_count.value, main_ignored_count.value))
+        print("{} crash pings processed, {} crash pings ignored".format(crash_processed_count.value, crash_ignored_count.value))
 
         current_date += timedelta(days=1)
 
     print("========================================")
     print("JOB COMPLETED SUCCESSFULLY")
-    print("{} main pings processed, {} main pings ignored".format(main_processed_count.value, main_ignored_count.value))
-    print("{} crash pings processed, {} crash pings ignored".format(crash_processed_count.value, crash_ignored_count.value))
     print("========================================")
 
 if __name__ == "__main__":

--- a/test/dataset.py
+++ b/test/dataset.py
@@ -16,6 +16,7 @@ ping_dimensions = {
     "os_version":        [u"6.1", u"3.1.12"],
     "architecture":      [u"x86", u"x86-64"],
     "e10s":              [True, False],
+    "e10s_cohort":       ["control", "test"],
     "country":           ["US", "UK"],
     "experiment_id":     [None, "displayport-tuning-nightly@experiments.mozilla.org"],
     "experiment_branch": ["control", "experiment"],
@@ -112,6 +113,7 @@ def generate_payload(dimensions):
         u"settings": {
             u"telemetryEnabled": True,
             u"e10sEnabled": dimensions["e10s"],
+            u"e10sCohort": dimensions["e10s_cohort"],
         },
         u"build": {
             u"version": dimensions["build_version"],

--- a/test/test_crash_aggregator.py
+++ b/test/test_crash_aggregator.py
@@ -26,12 +26,12 @@ COLUMN_DIMENSIONS = ["submission_date", "activity_date"]
 FOLDED_DIMENSIONS = ["doc_type"]
 
 
-class TestStringMethods(unittest.TestCase):
+class TestCrashAggregator(unittest.TestCase):
     def setUp(self):
         self.sc = pyspark.SparkContext(master="local[1]")
         self.raw_pings = self.sc.parallelize(list(dataset.generate_pings()))
 
-        result, self.ignored_count = compare_crashes(
+        result, self.main_processed_count, self.main_ignored_count, self.crash_processed_count, self.crash_ignored_count = compare_crashes(
             self.sc,
             self.raw_pings,
             COMPARABLE_DIMENSIONS, DIMENSION_NAMES
@@ -48,7 +48,10 @@ class TestStringMethods(unittest.TestCase):
             len(FOLDED_DIMENSIONS)
         )
         self.assertEqual(self.raw_pings.count(), expected_pings)
-        self.assertEqual(self.ignored_count.value, 0)
+        self.assertEqual(self.main_processed_count.value, expected_pings / 2)
+        self.assertEqual(self.crash_processed_count.value, expected_pings / 2)
+        self.assertEqual(self.main_ignored_count.value, 0)
+        self.assertEqual(self.crash_ignored_count.value, 0)
 
         # the doc_type dimension should be collapsed by compare_crashes
         self.assertEqual(len(self.crash_rate_aggregates), expected_pings / 2)

--- a/test/test_crash_aggregator.py
+++ b/test/test_crash_aggregator.py
@@ -106,6 +106,10 @@ class TestStringMethods(unittest.TestCase):
                 dimensions["e10s_enabled"],
                 ["True", "False"]
             )
+            self.assertIn(
+                dimensions["e10s_cohort"],
+                dataset.ping_dimensions["e10s_cohort"]
+            )
 
     def test_crash_rates(self):
         for activity_date, dimensions, stats in self.crash_rate_aggregates:


### PR DESCRIPTION
- Ignored and processed count for main and crash pings.
- Remove port bind in Vagrant so we don't take up a port we're not using - we don't need 5432 anymore since we switched away from postgres.
- Certain days have very small numbers of corrupted pings (<20 by my estimate). This causes errors on days like April 9. With these fixes in place, we either reject or handle these pings without stopping the job.
