### PR TITLE
Add e10s cohort dimension

### DIFF
--- a/crash_rate_aggregates/crash_aggregator.py
+++ b/crash_rate_aggregates/crash_aggregator.py
@@ -24,6 +24,7 @@ COMPARABLE_DIMENSIONS = [
     ("environment", "addons", "activeExperiment", "id"),
     ("environment", "addons", "activeExperiment", "branch"),
     ("environment", "settings", "e10sEnabled"),
+    ("environment", "settings", "e10sCohort"),
 ]
 
 # names of the comparable dimensions above, used as dimension names in the database
@@ -39,6 +40,7 @@ DIMENSION_NAMES = [
     "experiment_id",
     "experiment_branch",
     "e10s_enabled",
+    "e10s_cohort",
 ]
 
 assert len(COMPARABLE_DIMENSIONS) == len(DIMENSION_NAMES), \

--- a/test/dataset.py
+++ b/test/dataset.py
@@ -16,6 +16,7 @@ ping_dimensions = {
     "os_version":        [u"6.1", u"3.1.12"],
     "architecture":      [u"x86", u"x86-64"],
     "e10s":              [True, False],
+    "e10s_cohort":       ["control", "test"],
     "country":           ["US", "UK"],
     "experiment_id":     [None, "displayport-tuning-nightly@experiments.mozilla.org"],
     "experiment_branch": ["control", "experiment"],
@@ -112,6 +113,7 @@ def generate_payload(dimensions):
         u"settings": {
             u"telemetryEnabled": True,
             u"e10sEnabled": dimensions["e10s"],
+            u"e10sCohort": dimensions["e10s_cohort"],
         },
         u"build": {
             u"version": dimensions["build_version"],

--- a/test/test_crash_aggregator.py
+++ b/test/test_crash_aggregator.py
@@ -106,6 +106,10 @@ class TestStringMethods(unittest.TestCase):
                 dimensions["e10s_enabled"],
                 ["True", "False"]
             )
+            self.assertIn(
+                dimensions["e10s_cohort"],
+                dataset.ping_dimensions["e10s_cohort"]
+            )
 
     def test_crash_rates(self):
         for activity_date, dimensions, stats in self.crash_rate_aggregates:


### PR DESCRIPTION
As requested by :bsmedburg, the e10s cohort is necessary to do proper e10s vs non-e10s population comparisons starting with the beta46-apz experiment.
