### PR TITLE
Update bucket and bootstrap notebook

### DIFF
--- a/crash_rate_aggregates/crash_aggregator.py
+++ b/crash_rate_aggregates/crash_aggregator.py
@@ -284,7 +284,7 @@ def run_job(spark_context, sql_context, submission_date_range, use_test_data=Fal
 
         # upload the dataframe as Parquet to S3
         s3_result_url = (
-            "s3n://telemetry-test-bucket/crash_aggregates/v1/submission_date={}".format(
+            "s3n://telemetry-parquet/crash_aggregates/v1/submission_date={}".format(
                 current_date
             )
         )

--- a/run_crash_aggregator.ipynb
+++ b/run_crash_aggregator.ipynb
@@ -1,23 +1,44 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Crash Aggregator Bootstrap Notebook\n",
+    "Bootstraps and runs the [crash aggregator](https://github.com/mozilla/moz-crash-rate-aggregates) job from the latest source code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clone the crash aggregates repository and import the crash aggregator job:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "import os\n",
-    "os.system(\"git clone https://github.com/mozilla/moz-crash-rate-aggregates.git\")\n",
-    "os.chdir(\"moz-crash-rate-aggregates/crash_rate_aggregates\")\n",
+    "!git clone https://github.com/mozilla/moz-crash-rate-aggregates.git\n",
+    "%cd moz-crash-rate-aggregates/crash_rate_aggregates\n",
     "import crash_aggregator"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get yesterday's date as a YYYYMMDD string:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -28,8 +49,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the crash aggregator job:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -55,7 +83,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Currently we've been outputting results into telemetry-test-bucket. Eventually, we'll want to use telemetry-parquet instead, like the other parquet ones have been using.

Also, update the notebook so it's obvious what it does and where to find more information about it.

After this is merged, the cronjob on the Parquet2Hive instance needs to be updated as well.
